### PR TITLE
The command “lizardfs” replace all “mfs*” commands

### DIFF
--- a/clone
+++ b/clone
@@ -64,7 +64,7 @@ DST=`generate_image_path`
 if [ -n "$BRIDGE_LIST" ]; then
     log "Copying remotely local image $SRC to the image repository"
     DST_HOST=`get_destination_host $ID`
-    ssh_exec_and_log "$DST_HOST" "mkdir -p $BASE_PATH; mfsmakesnapshot $SRC $DST" "Error copying $SRC to $DST in $DST_HOST"
+    ssh_exec_and_log "$DST_HOST" "mkdir -p $BASE_PATH; lizardfs makesnapshot $SRC $DST" "Error copying $SRC to $DST in $DST_HOST"
 else
     log "Copying local image $SRC to the image repository"
     mkdir -p "$BASE_PATH"


### PR DESCRIPTION
* clone: use “lizardfs makesnapshot”.