### PR TITLE
Update for compatibily with OpenNebula 6.0.0.2

### DIFF
--- a/clone
+++ b/clone
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -64,11 +64,19 @@ DST=`generate_image_path`
 if [ -n "$BRIDGE_LIST" ]; then
     log "Copying remotely local image $SRC to the image repository"
     DST_HOST=`get_destination_host $ID`
-    ssh_exec_and_log "$DST_HOST" "mkdir -p $BASE_PATH; lizardfs makesnapshot $SRC $DST" "Error copying $SRC to $DST in $DST_HOST"
+
+    CMD=$(cat <<EOF
+        set -e -o pipefail
+        mkdir -p $BASE_PATH
+        lizardfs makesnapshot -o $SRC $DST
+EOF
+)
+
+    ssh_exec_and_log "$DST_HOST" "${CMD}" "Error copying $SRC to $DST in $DST_HOST"
 else
     log "Copying local image $SRC to the image repository"
     mkdir -p "$BASE_PATH"
-    exec_and_log "mfsmakesnapshot  $SRC $DST" "Error copying $SRC to $DST"
+    exec_and_log "lizardfs makesnapshot -o $SRC $DST" "Error copying $SRC to $DST"
 fi
 
 echo "$DST"

--- a/cp
+++ b/cp
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -33,6 +33,7 @@ fi
 
 DRIVER_PATH=$(dirname $0)
 source ${DRIVER_PATH}/../libfs.sh
+source ${DRIVER_PATH}/../../etc/datastore/fs/fs.conf
 
 # -------- Get cp and datastore arguments from OpenNebula core ------------
 
@@ -59,7 +60,11 @@ done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/BASE_PATH \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TEMPLATE/MD5 \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TEMPLATE/SHA1 \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/NO_DECOMPRESS \
-                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/LIMIT_TRANSFER_BW)
+                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/LIMIT_TRANSFER_BW \
+                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/CONVERT \
+                    /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/DRIVER \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/TYPE \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/TEMPLATE/URL_ARGS)
 
 unset i
 
@@ -74,6 +79,10 @@ MD5="${XPATH_ELEMENTS[i++]}"
 SHA1="${XPATH_ELEMENTS[i++]}"
 NO_DECOMPRESS="${XPATH_ELEMENTS[i++]}"
 LIMIT_TRANSFER_BW="${XPATH_ELEMENTS[i++]}"
+CONVERT="${XPATH_ELEMENTS[i++]:-yes}"
+DRIVER="${XPATH_ELEMENTS[i++]}"
+IMAGE_TYPE="${XPATH_ELEMENTS[i++]}"
+URL_ARGS="${XPATH_ELEMENTS[i++]}"
 
 DST=`generate_image_path`
 IMAGE_HASH=`basename $DST`
@@ -85,6 +94,17 @@ if [ "$TYPE" = "2" ]; then
     NO_DECOMPRESS="${NO_DECOMPRESS:-yes}"
 fi
 
+# Disable conversion for CD-ROM and 'files' datastores
+CONVERT=$(echo "${CONVERT}" | $TR '[:upper:]' '[:lower:]')
+if [ "$IMAGE_TYPE" = "1" ] || [ "$TYPE" = "2" ]; then
+    CONVERT=no
+fi
+
+# Append URL args to SRC url
+if [ ! -z $URL_ARGS ]; then
+    SRC+="&$URL_ARGS"
+fi
+
 if [ -n "$BRIDGE_LIST" ]; then
     DOWNLOADER_ARGS=`set_downloader_args "$MD5" "$SHA1" "$NO_DECOMPRESS" "$LIMIT_TRANSFER_BW" "$SRC" -`
 else
@@ -94,30 +114,65 @@ fi
 COPY_COMMAND="$UTILS_PATH/downloader.sh $DOWNLOADER_ARGS"
 
 if echo "$SRC" | grep -vq '^https\?://'; then
-
-#    if [ `check_restricted $SRC` -eq 1 ]; then
-#        log_error "Not allowed to copy images from $RESTRICTED_DIRS"
-#        error_message "Not allowed to copy image file $SRC"
-#        exit -1
-#    fi
+    if [ `check_restricted $SRC` -eq 1 ]; then
+        log_error "Not allowed to copy images from $RESTRICTED_DIRS"
+        error_message "Not allowed to copy image from $SRC, check RESTRICTED_DIRS in your datastore"
+        exit -1
+    fi
 
     log "Copying local image $SRC to the image repository"
 else
     log "Downloading image $SRC to the image repository"
 fi
 
+CONVERT_CMD=$(cat <<EOF
+    set -e -o pipefail
+    FORMAT=\$($QEMU_IMG info $DST | grep "^file format:" | awk '{print \$3}' || :)
+
+    if [ "x$DRIVER" = 'xqcow2' ] || [ "x$DRIVER" = 'xraw' ]; then
+        if [ -n "\$FORMAT" ] && [ "\$FORMAT" != "$DRIVER" ] && [ "\$FORMAT" != "luks" ]; then
+            $QEMU_IMG convert -O $DRIVER $DST $DST.tmp
+            mv $DST.tmp $DST
+        fi
+    fi
+EOF
+)
+
 if [ -n "$BRIDGE_LIST" ]; then
     DST_HOST=`get_destination_host $ID`
     TMP_DST="$STAGING_DIR/$IMAGE_HASH"
 
-    exec_and_log "eval $COPY_COMMAND | $SSH $DST_HOST $DD of=$TMP_DST bs=64k" \
+    multiline_exec_and_log "set -e -o pipefail; $COPY_COMMAND | $SSH $DST_HOST $DD of=$TMP_DST bs=${DD_BLOCK_SIZE:-64k} conv=sparse" \
                  "Error dumping $SRC to $DST_HOST:$TMP_DST"
 
-    ssh_exec_and_log    "$DST_HOST" "mkdir -p $BASE_PATH; mv -f $TMP_DST $DST" \
+    ssh_exec_and_log    "$DST_HOST" "set -e -o pipefail; mkdir -p $BASE_PATH; mv -f $TMP_DST $DST" \
                         "Error moving $TMP_DST to $DST in $DST_HOST"
+
+    if [ "x$CONVERT" = 'xyes' ] && [ -n "$DRIVER" ]; then
+        ssh_exec_and_log "$DST_HOST" "$CONVERT_CMD" \
+                         "Error converting $DST in $DST_HOST"
+    fi
+
+    FORMAT=$(ssh_monitor_and_log $DST_HOST "set -e -o pipefail; $QEMU_IMG info $DST | grep \"^file format:\" | awk '{print \$3}'")
+
+    # if ssh_monitor_and_log fails RC is returned
+    if [[ $FORMAT =~ '^[0-9]+$' ]]; then
+        exit -1
+    fi
+
 else
     mkdir -p "$BASE_PATH"
-    exec_and_log "$COPY_COMMAND" "Error copying $SRC to $DST"
+    multiline_exec_and_log "set -e -o pipefail; $COPY_COMMAND" "Error copying $SRC to $DST"
+
+    if [ "x$CONVERT" = 'xyes' ] && [ -n "$DRIVER" ]; then
+        multiline_exec_and_log "$CONVERT_CMD" "Error converting $DST"
+    fi
+
+    fallocate -d "$DST" &> /dev/null || true # Avoid errors if fallocate not supported by FS
+
+    FORMAT=$($QEMU_IMG info $DST | grep "^file format:" | awk '{print $3}' || :)
 fi
 
-echo "$DST"
+[[ "$FORMAT" = "luks" ]] && FORMAT="raw"
+
+echo "$DST $FORMAT"

--- a/export
+++ b/export
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -45,10 +45,12 @@ unset i XPATH_ELEMENTS
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
 done < <($XPATH     /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/SIZE \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST)
 unset i
 
 SRC="${XPATH_ELEMENTS[i++]}"
+SIZE="${XPATH_ELEMENTS[i++]}"
 BRIDGE_LIST="${XPATH_ELEMENTS[i++]}"
 
 #-------------------------------------------------------------------------------
@@ -57,16 +59,15 @@ BRIDGE_LIST="${XPATH_ELEMENTS[i++]}"
 
 INFO_SCRIPT=$(cat <<EOF
 CHECKSUM=\$(${MD5SUM} ${SRC} | cut -f1 -d' ')
-SIZE=\$(${DU} -Lm ${SRC} | cut -f1)
 FORMAT=\$(${QEMU_IMG} info ${SRC} 2>/dev/null | grep -Po '(?<=file format: )\w+')
 
-if [ -z "\$CHECKSUM" -o -z "\$SIZE" ]; then
+if [ -z "\$CHECKSUM" ]; then
     exit 1
 fi
 
 echo "<MD5><![CDATA[\$CHECKSUM]]></MD5>"
-echo "<SIZE><![CDATA[\$SIZE]]></SIZE>"
-echo "<FORMAT><![CDATA[\${FORMAT:-unknown}]]></FORMAT>"
+echo "<SIZE><![CDATA[${SIZE}]]></SIZE>"
+echo "<FORMAT><![CDATA[\${FORMAT:-raw}]]></FORMAT>"
 EOF
 )
 

--- a/mkfs
+++ b/mkfs
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -33,6 +33,7 @@ fi
 
 DRIVER_PATH=$(dirname $0)
 source ${DRIVER_PATH}/../libfs.sh
+source ${DRIVER_PATH}/../../etc/datastore/datastore.conf
 
 # -------- Get mkfs and datastore arguments from OpenNebula core ------------
 
@@ -49,8 +50,9 @@ done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/BASE_PATH \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/RESTRICTED_DIRS \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/SAFE_DIRS \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST \
-                    /DS_DRIVER_ACTION_DATA/IMAGE/FSTYPE \
-                    /DS_DRIVER_ACTION_DATA/IMAGE/SIZE)
+                    /DS_DRIVER_ACTION_DATA/IMAGE/FORMAT \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/SIZE \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/FS )
 
 unset i
 
@@ -58,23 +60,26 @@ BASE_PATH="${XPATH_ELEMENTS[i++]}"
 RESTRICTED_DIRS="${XPATH_ELEMENTS[i++]}"
 SAFE_DIRS="${XPATH_ELEMENTS[i++]}"
 BRIDGE_LIST="${XPATH_ELEMENTS[i++]}"
-FSTYPE="${XPATH_ELEMENTS[i++]}"
+FORMAT="${XPATH_ELEMENTS[i++]}"
 SIZE="${XPATH_ELEMENTS[i++]}"
+FS="${XPATH_ELEMENTS[i++]}"
 
 set_up_datastore "$BASE_PATH" "$RESTRICTED_DIRS" "$SAFE_DIRS"
 
 DST=`generate_image_path`
 
-# ------------ Image to save_as disk, no need to create a FS ------------
+# ------------ Image to save_as disk, no need to create a new image ------------
 
-if [ "$FSTYPE" = "save_as" ]; then
+if [ "$FORMAT" = "save_as" ]; then
     echo "$DST"
     exit 0
 fi
 
 # ------------ Create the image to the repository ------------
+set -e -o pipefail
 
-MKFS_CMD=`mkfs_command $DST $FSTYPE $SIZE`
+FS_OPTS=$(eval $(echo "echo \$FS_OPTS_$FS"))
+MKFS_CMD=`mkfs_command $DST $FORMAT $SIZE "$SUPPORTED_FS" "$FS" "$FS_OPTS"`
 
 REMOTE_REGISTER_CMD=$(cat <<EOF
     set -e -o pipefail
@@ -90,13 +95,13 @@ if [ -n "$BRIDGE_LIST" ]; then
     DST_HOST=`get_destination_host $ID`
 
     ssh_exec_and_log "$DST_HOST" "$REMOTE_REGISTER_CMD" \
-        "Unable to create filesystem $FSTYPE in $DST_HOST:$DST"
+        "Unable to create image with format $FORMAT in $DST_HOST:$DST"
 
 else
     mkdir -p "$BASE_PATH"
 
     multiline_exec_and_log "$MKFS_CMD" \
-        "Unable to create filesystem $FSTYPE in $DST"
+        "Unable to create image with format $FORMAT in $DST"
 fi
 
 echo "$DST"

--- a/monitor
+++ b/monitor
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -83,13 +83,6 @@ else
 fi
 
 MONITOR_STATUS=$?
-#/var/lib/one/remotes/datastore/setgoal.sh action /var/lib/one/log > /dev/null 2>&1
-#/var/lib/one/remotes/datastore/setgoal.sh action /var/lib/one/datastores > /dev/null 2>&1
-#/var/lib/one/remotes/datastore/setgoal.sh action /var/lib/one/vms > /dev/null 2>&1
-#/var/lib/one/remotes/datastore/setgoal.sh action /var/lib/one/nginx > /dev/null 2>&1
-#/var/lib/one/remotes/datastore/setgoal.sh action /var/lib/one/remotes > /dev/null 2>&1
-#/var/lib/one/remotes/datastore/setgoal.sh action /var/lib/one/sunstone_vnc_tokens > /dev/null 2>&1
-
 
 if [ "$MONITOR_STATUS" = "0" ]; then
     echo "$MONITOR_DATA" | tr ' ' '\n'

--- a/rm
+++ b/rm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -59,7 +59,7 @@ BASE_PATH="${XPATH_ELEMENTS[i++]}"
 if [ -n "$BRIDGE_LIST" ]; then
     DST_HOST=`get_destination_host $ID`
 
-    ssh_exec_and_log "$DST_HOST" "[ -f $SRC ] && rm -rf $SRC $SRC.snap" \
+    ssh_exec_and_log "$DST_HOST" "[ -f $SRC ] && rm -rf $SRC $SRC.snap $SRC.md5sum" \
         "Error deleting $SRC in $DST_HOST"
 else
     BASENAME_SRC=`basename "${SRC##$REMOTE_RM_CMD}"`
@@ -67,7 +67,7 @@ else
     then
         log "Removing $SRC from the image repository"
 
-        exec_and_log "rm -rf $SRC $SRC.snap" \
+        exec_and_log "rm -rf $SRC $SRC.snap $SRC.md5sum" \
             "Error deleting $SRC"
     else
         log_error "Bad formed or unavailable Image source: ${SRC}"

--- a/snap_delete
+++ b/snap_delete
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -22,14 +22,17 @@ ID=$2
 if [ -z "${ONE_LOCATION}" ]; then
     TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
     DATASTORES=/var/lib/one/datastores
+    LIB_LOCATION=/usr/lib/one
 else
     TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
     DATASTORES=$ONE_LOCATION/var/datastores
+    LIB_LOCATION=$ONE_LOCATION/lib
 fi
 
 . $TMCOMMON
 
 DRIVER_PATH=$(dirname $0)
+source ${DRIVER_PATH}/../libfs.sh
 
 # -------- Get image and datastore arguments from OpenNebula core ------------
 
@@ -42,9 +45,11 @@ unset i j XPATH_ELEMENTS
 
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
-done < <($XPATH     /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
+done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TARGET_SNAPSHOT)
 
+BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 DISK_SRC="${XPATH_ELEMENTS[j++]}"
 SNAP_ID="${XPATH_ELEMENTS[j++]}"
 
@@ -55,5 +60,17 @@ SYSTEM_DS_PATH=$(dirname ${SRC_PATH})
 SNAP_DIR="${DISK_SRC}.snap"
 SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 
-rm ${SNAP_PATH}
+if [ -n "$BRIDGE_LIST" ]; then
+    log "Delete remote snapshot $SNAP_PATH"
+    DST_HOST=`get_destination_host $ID`
 
+    ssh_exec_and_log "$DST_HOST" "rm $SNAP_PATH" \
+        "Error deleting snapshot $SNAP_PATH"
+else
+    log "Delete local snapshot $SNAP_PATH"
+
+    exec_and_log "rm ${SNAP_PATH}" \
+        "Error deleting snapshot $SNAP_PATH"
+
+    rm -f ${SRC_PATH}.md5sum
+fi

--- a/snap_flatten
+++ b/snap_flatten
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -22,14 +22,17 @@ ID=$2
 if [ -z "${ONE_LOCATION}" ]; then
     TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
     DATASTORES=/var/lib/one/datastores
+    LIB_LOCATION=/usr/lib/one
 else
     TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
     DATASTORES=$ONE_LOCATION/var/datastores
+    LIB_LOCATION=$ONE_LOCATION/lib
 fi
 
 . $TMCOMMON
 
 DRIVER_PATH=$(dirname $0)
+source ${DRIVER_PATH}/../libfs.sh
 
 # -------- Get image and datastore arguments from OpenNebula core ------------
 
@@ -42,10 +45,12 @@ unset i j XPATH_ELEMENTS
 
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
-done < <($XPATH     /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
+done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TARGET_SNAPSHOT \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TM_MAD )
 
+BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 DISK_SRC="${XPATH_ELEMENTS[j++]}"
 SNAP_ID="${XPATH_ELEMENTS[j++]}"
 TM_MAD="${XPATH_ELEMENTS[j++]}"
@@ -61,10 +66,44 @@ SNAP_DIR="${DISK_PATH}.snap"
 SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 
 if [ "$TM_MAD" = "qcow2" ]; then
-    qemu-img convert -O qcow2 ${SNAP_PATH} ${DISK_PATH}.tmp
-    mv "${DISK_PATH}.tmp" "${DISK_PATH}"
-else
-    mv ${SNAP_PATH} ${DISK_PATH}
-fi
+    if [ -n "$BRIDGE_LIST" ]; then
+        DST_HOST=`get_destination_host $ID`
 
-rm -rf ${SNAP_DIR}
+        ssh_exec_and_log "$DST_HOST" "qemu-img convert -O qcow2 ${SNAP_PATH} ${DISK_PATH}.tmp" \
+            "Error flattening ${SNAP_PATH}"
+
+        ssh_exec_and_log "$DST_HOST" "mv ${DISK_PATH}.tmp ${DISK_PATH}" \
+            "Error moving to ${DISK_PATH}"
+
+        ssh_exec_and_log "$DST_HOST" "rm -rf ${SNAP_DIR}" \
+            "Error removing ${SNAP_DIR}"
+    else
+        exec_and_log "qemu-img convert -O qcow2 ${SNAP_PATH} ${DISK_PATH}.tmp" \
+            "Error flattening ${SNAP_PATH}"
+
+        exec_and_log "mv ${DISK_PATH}.tmp ${DISK_PATH}" \
+            "Error moving to ${DISK_PATH}"
+
+        exec_and_log "rm -rf ${SNAP_DIR}" \
+            "Error removing ${SNAP_DIR}"
+    fi
+
+else
+    if [ -n "$BRIDGE_LIST" ]; then
+        DST_HOST=`get_destination_host $ID`
+
+        ssh_exec_and_log "$DST_HOST" "lizardfs makesnapshot -o ${SNAP_PATH} ${DISK_PATH}" \
+            "Error moving snapshot ${SNAP_PATH}"
+
+        ssh_exec_and_log "$DST_HOST" "rm -rf ${SNAP_DIR}" \
+            "Error removing ${SNAP_DIR}"
+    else
+        exec_and_log "lizardfs makesnapshot -o ${SNAP_PATH} ${DISK_PATH}" \
+            "Error moving snapshot ${SNAP_PATH}"
+
+        exec_and_log "rm -rf ${SNAP_DIR}" \
+            "Error removing ${SNAP_DIR}"
+
+        rm -f ${SRC_PATH}.md5sum
+    fi
+fi

--- a/snap_revert
+++ b/snap_revert
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -22,14 +22,17 @@ ID=$2
 if [ -z "${ONE_LOCATION}" ]; then
     TMCOMMON=/var/lib/one/remotes/tm/tm_common.sh
     DATASTORES=/var/lib/one/datastores
+    LIB_LOCATION=/usr/lib/one
 else
     TMCOMMON=$ONE_LOCATION/var/remotes/tm/tm_common.sh
     DATASTORES=$ONE_LOCATION/var/datastores
+    LIB_LOCATION=$ONE_LOCATION/lib
 fi
 
 . $TMCOMMON
 
 DRIVER_PATH=$(dirname $0)
+source ${DRIVER_PATH}/../libfs.sh
 
 # -------- Get image and datastore arguments from OpenNebula core ------------
 
@@ -42,10 +45,12 @@ unset i j XPATH_ELEMENTS
 
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
-done < <($XPATH     /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
+done < <($XPATH     /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/BRIDGE_LIST \
+                    /DS_DRIVER_ACTION_DATA/IMAGE/SOURCE \
                     /DS_DRIVER_ACTION_DATA/IMAGE/TARGET_SNAPSHOT \
                     /DS_DRIVER_ACTION_DATA/DATASTORE/TM_MAD )
 
+BRIDGE_LIST="${XPATH_ELEMENTS[j++]}"
 DISK_SRC="${XPATH_ELEMENTS[j++]}"
 SNAP_ID="${XPATH_ELEMENTS[j++]}"
 TM_MAD="${XPATH_ELEMENTS[j++]}"
@@ -58,12 +63,43 @@ SNAP_DIR="${DISK_SRC}.snap"
 SNAP_PATH="${SNAP_DIR}/${SNAP_ID}"
 
 if [ "$TM_MAD" = "qcow2" ]; then
-    ACTIVE_SNAP_ID=$(ls ${SNAP_DIR} | sort -n | tail -n 1)
-    ACTIVE_SNAP_PATH="${SNAP_DIR}/${ACTIVE_SNAP_ID}"
+    SNAP_ID_SCRIPT=$(cat <<EOF
+set -e -o pipefail
+ls $SNAP_DIR | grep '^[[:digit:]]*\$' | sort -n | tail -n 1
+EOF
+)
+    if [ -n "$BRIDGE_LIST" ]; then
+        DST_HOST=`get_destination_host $ID`
 
-    rm ${ACTIVE_SNAP_PATH}
-    qemu-img create -f qcow2 -b ${SNAP_PATH} ${ACTIVE_SNAP_PATH}
+        ACTIVE_SNAP_ID=$(ssh_monitor_and_log "$DST_HOST" "$SNAP_ID_SCRIPT" "Error get active snapshot ID" 2>&1)
+        ACTIVE_SNAP_PATH="${SNAP_DIR}/${ACTIVE_SNAP_ID}"
+
+        ssh_exec_and_log "$DST_HOST" "rm $ACTIVE_SNAP_PATH" \
+            "Error deleting $ACTIVE_SNAP_PATH"
+
+        ssh_exec_and_log "$DST_HOST" "qemu-img create -f qcow2 -o backing_fmt=qcow2 -b $SNAP_PATH $ACTIVE_SNAP_PATH" \
+            "Error reverting snapshot to $SNAP_PATH"
+    else
+        ACTIVE_SNAP_ID=$(monitor_and_log "$SNAP_ID_SCRIPT" "Error get active snapshot ID" 2>&1)
+        ACTIVE_SNAP_PATH="${SNAP_DIR}/${ACTIVE_SNAP_ID}"
+
+        exec_and_log "rm ${ACTIVE_SNAP_PATH}" \
+            "Error deleting $ACTIVE_SNAP_PATH"
+
+        exec_and_log "qemu-img create -f qcow2 -o backing_fmt=qcow2 -b ${SNAP_PATH} ${ACTIVE_SNAP_PATH}" \
+            "Error reverting snapshot to $SNAP_PATH"
+    fi
 else
-    mv ${SNAP_PATH} ${DISK_SRC}
-fi
+    if [ -n "$BRIDGE_LIST" ]; then
+        DST_HOST=`get_destination_host $ID`
 
+        ssh_exec_and_log "$DST_HOST" "lizardfs makesnapshot -o ${SNAP_PATH} ${DISK_SRC}" \
+            "Error copying snapshot $SNAP_PATH"
+
+    else
+        exec_and_log "lizardfs makesnapshot -o ${SNAP_PATH} ${DISK_SRC}" \
+            "Error copying snapshot $SNAP_PATH"
+
+        rm -f ${DISK_SRC}.md5sum
+    fi
+fi

--- a/stat
+++ b/stat
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------- #
-# Copyright 2002-2017, OpenNebula Project, OpenNebula Systems                #
+# Copyright 2002-2021, OpenNebula Project, OpenNebula Systems                #
 #                                                                            #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may    #
 # not use this file except in compliance with the License. You may obtain    #
@@ -45,19 +45,30 @@ unset i XPATH_ELEMENTS
 
 while IFS= read -r -d '' element; do
     XPATH_ELEMENTS[i++]="$element"
-done < <($XPATH /DS_DRIVER_ACTION_DATA/IMAGE/PATH)
+done < <($XPATH /DS_DRIVER_ACTION_DATA/IMAGE/PATH \
+                /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/NO_DECOMPRESS \
+                /DS_DRIVER_ACTION_DATA/DATASTORE/TEMPLATE/LIMIT_TRANSFER_BW)
 
-SRC="${XPATH_ELEMENTS[0]}"
+unset i
+
+SRC="${XPATH_ELEMENTS[i++]}"
+NO_DECOMPRESS="${XPATH_ELEMENTS[i++]}"
+LIMIT_TRANSFER_BW="${XPATH_ELEMENTS[i++]}"
 
 # ------------------------------------------------------------------------------
 #  Compute the size
 # ------------------------------------------------------------------------------
 
-SIZE=`fs_size $SRC`
+SIZE=`fs_size "${SRC}" "${NO_DECOMPRESS}" "${LIMIT_TRANSFER_BW}"`
 
-if [ "$SIZE" = "0" ]; then
-    log_error "Cannot determine size for $SRC"
+if [ $? -ne 0 ]; then
+    if [ "${SIZE:-0}" = '0' ]; then
+        error_message "Cannot determine size for ${SRC}"
+    else
+        error_message "${SIZE}"
+    fi
+
     exit -1
 fi
 
-echo "$SIZE"
+echo "${SIZE}"


### PR DESCRIPTION
This driver is updated with code from 6.0.0.2 fs datastore driver.

It replace a forgotten `mfsmakesnapshot` with `lizardfs makesnapshot`.